### PR TITLE
Fix placeholder errors to make Travis tests pass.

### DIFF
--- a/bundles/org.openhab.binding.resol/src/main/java/org/openhab/binding/resol/handler/ResolBridgeHandler.java
+++ b/bundles/org.openhab.binding.resol/src/main/java/org/openhab/binding/resol/handler/ResolBridgeHandler.java
@@ -421,7 +421,7 @@ public class ResolBridgeHandler extends BaseBridgeHandler {
                 try {
                     tcpConnection.connect();
                 } catch (IOException e) {
-                    logger.trace("Connection failed", e.getMessage());
+                    logger.trace("Connection failed: {}", e.getMessage());
                     unconnectedReason = e.getMessage();
                     isConnected = false;
                 }

--- a/bundles/org.openhab.binding.resol/src/main/java/org/openhab/binding/resol/handler/ResolThingHandler.java
+++ b/bundles/org.openhab.binding.resol/src/main/java/org/openhab/binding/resol/handler/ResolThingHandler.java
@@ -88,7 +88,7 @@ public class ResolThingHandler extends BaseThingHandler {
 
         Bridge bridge = getBridge();
         if (bridge == null) {
-            logger.debug("Required bridge not defined for device {}.");
+            logger.debug("Required bridge not defined for device.");
             return null;
         } else {
             return getBridgeHandler(bridge);


### PR DESCRIPTION
I saw that the Travis CI test fail currently due to incorrect use of log message placeholders. This commit fixes the problems, making tests pass. 